### PR TITLE
R8による難読化でJackson周りで発生するエラーの修正

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,10 +11,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
--keepclassmembers class net.mythrowaway.app.view.AccountLinkActivity {
-   public *;
-}
-
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 -keepattributes SourceFile,LineNumberTable
@@ -34,7 +30,6 @@
 -keepattributes LineNumberTable,SourceFile
 
 # Jackson用の設定
--keepattributes SourceFile,LineNumberTable,*Annotation*,EnclosingMethod,Signature,Exceptions,InnerClasses
 -keep @com.fasterxml.jackson.annotation.JsonIgnoreProperties class * { *; }
 -keep @com.fasterxml.jackson.annotation.JsonCreator class * { *; }
 -keep @com.fasterxml.jackson.annotation.JsonValue class * { *; }
@@ -44,15 +39,19 @@
 -keepclassmembers public final enum com.fasterxml.jackson.annotation.JsonAutoDetect$Visibility {
     public static final com.fasterxml.jackson.annotation.JsonAutoDetect$Visibility *;
 }
+-keep class com.fasterxml.jackson.databind.** { *; }
+-keep class **.TypeReference { *; }
+-keepattributes SourceFile,LineNumberTable,*Annotation*,EnclosingMethod,Signature,Exceptions,InnerClasses
 
--keep public class net.mythrowaway.app.domain.** {
-    public void set*(***);
-    public *** get*();
+-keep class net.mythrowaway.app.domain.** {
+    *;
 }
 -keep public class net.mythrowaway.app.adapter.** {
-    public void set*(***);
-    public *** get*();
+    *;
 }
--keep class net.nend.android.** { *; }
+-keep class net.mythrowaway.app.service.TrashDataListTypeReference {*;}
+-keepclassmembers class * extends android.app.Activity {
+   public void *(android.view.View);
+}
 -dontwarn java.beans.ConstructorProperties
 -dontwarn java.beans.Transient

--- a/app/src/main/java/net/mythrowaway/app/service/TrashDataConverter.kt
+++ b/app/src/main/java/net/mythrowaway/app/service/TrashDataConverter.kt
@@ -1,11 +1,12 @@
 package net.mythrowaway.app.service
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.module.kotlin.readValue
 import net.mythrowaway.app.domain.TrashData
 
+class TrashDataListTypeReference: TypeReference<ArrayList<TrashData>>(){}
 open class TrashDataConverter {
     protected fun jsonToTrashData(stringData: String): TrashData {
         val mapper = ObjectMapper()
@@ -13,9 +14,10 @@ open class TrashDataConverter {
     }
 
     protected fun jsonToTrashList(stringData: String): ArrayList<TrashData> {
+        print(stringData)
         val mapper = ObjectMapper()
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-        return mapper.readValue(stringData)
+        return mapper.readValue(stringData,TrashDataListTypeReference())
     }
 
     protected fun trashDataToJson(trashData: TrashData): String {


### PR DESCRIPTION
- TypeReferenceを継承する無名クラスを名前付きクラスに変更
- proguard-rules.pro内のnet.mythrowaway.app.adapterの名前保持対象スコープを全体に修正