### PR TITLE
SDK34以降利用不可となったライブラリの更新

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     implementation 'com.github.kittinunf.fuel:fuel:2.3.1'
     implementation 'com.github.kittinunf.fuel:fuel-json:2.3.1'
     implementation 'com.github.kittinunf.fuel:fuel-android:2.3.1'
-    implementation 'com.google.android.play:core-ktx:1.8.1'
+    implementation 'com.google.android.play:review-ktx:2.0.1'
     implementation 'com.google.dagger:dagger:2.48'
     kapt 'com.google.dagger:dagger-compiler:2.48'
 


### PR DESCRIPTION
- `com.google.android.play:core-ktx` を `com.google.android.play:review-ktx` に変更